### PR TITLE
Fix background removal worker overload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # API Authentication
 API_KEY=your_api_key_here
+
+# Background removal capacity and source image download limits
+BACKGROUND_REMOVAL_CONCURRENCY=1
+BACKGROUND_REMOVAL_MAX_IN_FLIGHT=6
+IMAGE_DOWNLOAD_CONNECT_TIMEOUT_SECONDS=5
+IMAGE_DOWNLOAD_READ_TIMEOUT_SECONDS=15

--- a/README.md
+++ b/README.md
@@ -118,3 +118,10 @@ curl -X POST "http://$REMOTE_HOST/api/v1/remove-background" -H "Content-Type: ap
 ```
 
 The endpoint returns a PNG image with transparent background. Any errors will be returned as plain text with a 400 status code.
+
+Background removal runs in a bounded queue so synchronous GPU work does not block
+the FastAPI event loop or health checks. The defaults allow one active GPU job and
+six total active or queued requests per worker. Additional requests receive HTTP
+503 with `Retry-After: 5`. Source image downloads use a 5-second connect timeout
+and a 15-second read timeout. These values can be changed with the corresponding
+variables in `.env.example`.

--- a/remote_inference/api.py
+++ b/remote_inference/api.py
@@ -1,14 +1,36 @@
 """API server for remote inference."""
+import os
 import time
 from typing import Annotated, List
 from fastapi import Depends, FastAPI, Response, status
 from pydantic import BaseModel, HttpUrl
 
 from remote_inference.auth import get_api_key
+from remote_inference.capacity import BoundedWorkQueue
 from remote_inference.ml import embedder
 from remote_inference import background_removal
 
 app = FastAPI(title="Remote Inference API")
+
+
+def positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer environment setting."""
+    value = int(os.getenv(name, str(default)))
+    if value < 1:
+        raise RuntimeError(f"{name} must be at least 1")
+    return value
+
+
+BACKGROUND_REMOVAL_CONCURRENCY = positive_int_env(
+    "BACKGROUND_REMOVAL_CONCURRENCY", 1
+)
+BACKGROUND_REMOVAL_MAX_IN_FLIGHT = positive_int_env(
+    "BACKGROUND_REMOVAL_MAX_IN_FLIGHT", 6
+)
+_background_removal_queue = BoundedWorkQueue(
+    BACKGROUND_REMOVAL_CONCURRENCY,
+    BACKGROUND_REMOVAL_MAX_IN_FLIGHT
+)
 
 
 class ImageQuery(BaseModel):
@@ -76,28 +98,40 @@ class BackgroundRemovalRequest(BaseModel):
 
 
 @app.post("/api/v1/remove-background", response_class=Response)
-async def remove_background_endpoint(
+def remove_background_endpoint(
     request: BackgroundRemovalRequest,
     _: None = Depends(get_api_key)
 ) -> Response:
     """Remove background from image at URL and return the processed image."""
-    print(f"\nProcessing background removal request for: {request.image_url}")
-    try:
-        import sys
-        sys.stdout.flush()  # Ensure prints are flushed immediately
-        image_buffer, mime_type = background_removal.remove_background(request.image_url)
-        print("Background removal completed successfully")
-        sys.stdout.flush()
-        return Response(
-            content=image_buffer.getvalue(),
-            media_type=mime_type
-        )
-    except ValueError as e:
-        return Response(
-            content=str(e),
-            media_type="text/plain",
-            status_code=400
-        )
+    queued_at = time.time()
+    with _background_removal_queue.reserve() as reserved:
+        if not reserved:
+            return Response(
+                content="Background removal queue is full",
+                media_type="text/plain",
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                headers={"Retry-After": "5"}
+            )
+
+        print(f"\nProcessing background removal request for: {request.image_url}")
+        queue_wait = time.time() - queued_at
+        print(f"Background removal queue wait: {queue_wait:.2f}s")
+        try:
+            import sys
+            sys.stdout.flush()  # Ensure prints are flushed immediately
+            image_buffer, mime_type = background_removal.remove_background(request.image_url)
+            print("Background removal completed successfully")
+            sys.stdout.flush()
+            return Response(
+                content=image_buffer.getvalue(),
+                media_type=mime_type
+            )
+        except ValueError as e:
+            return Response(
+                content=str(e),
+                media_type="text/plain",
+                status_code=400
+            )
 
 
 if __name__ == "__main__":

--- a/remote_inference/background_removal.py
+++ b/remote_inference/background_removal.py
@@ -1,6 +1,7 @@
 """Background removal using BiRefNet."""
 import base64
 import io
+import os
 import time
 from typing import Tuple, Union
 import torch
@@ -9,6 +10,19 @@ from transformers import AutoModelForImageSegmentation
 from PIL import Image
 import requests
 from pydantic import HttpUrl
+
+
+BROWSER_REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/138.0.0.0 Safari/537.36"
+    )
+}
+IMAGE_DOWNLOAD_TIMEOUT = (
+    float(os.getenv("IMAGE_DOWNLOAD_CONNECT_TIMEOUT_SECONDS", "5")),
+    float(os.getenv("IMAGE_DOWNLOAD_READ_TIMEOUT_SECONDS", "15")),
+)
 
 
 class BackgroundRemover:
@@ -51,7 +65,11 @@ class BackgroundRemover:
     def load_image_from_url(self, url: Union[str, HttpUrl]) -> Image.Image:
         """Load an image from a URL."""
         # Standard request without streaming for reliability
-        response = requests.get(str(url))
+        response = requests.get(
+            str(url),
+            headers=BROWSER_REQUEST_HEADERS,
+            timeout=IMAGE_DOWNLOAD_TIMEOUT
+        )
         response.raise_for_status()
         image_bytes = io.BytesIO(response.content)
         return Image.open(image_bytes).convert('RGB')

--- a/remote_inference/capacity.py
+++ b/remote_inference/capacity.py
@@ -1,0 +1,40 @@
+"""Bounded execution capacity for synchronous inference work."""
+from contextlib import contextmanager
+from threading import BoundedSemaphore, Lock
+from typing import Iterator
+
+
+class BoundedWorkQueue:
+    """Limit active work and reject requests beyond a bounded backlog."""
+
+    def __init__(self, concurrency: int, max_in_flight: int):
+        if concurrency < 1:
+            raise ValueError("concurrency must be at least 1")
+        if max_in_flight < concurrency:
+            raise ValueError("max_in_flight must be greater than or equal to concurrency")
+
+        self._slots = BoundedSemaphore(concurrency)
+        self._count_lock = Lock()
+        self._in_flight = 0
+        self._max_in_flight = max_in_flight
+
+    @contextmanager
+    def reserve(self) -> Iterator[bool]:
+        """Reserve queue capacity and an execution slot when available."""
+        with self._count_lock:
+            if self._in_flight >= self._max_in_flight:
+                accepted = False
+            else:
+                self._in_flight += 1
+                accepted = True
+
+        if not accepted:
+            yield False
+            return
+
+        try:
+            with self._slots:
+                yield True
+        finally:
+            with self._count_lock:
+                self._in_flight -= 1

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,49 @@
+"""Tests for bounded synchronous inference capacity."""
+import threading
+import time
+import unittest
+
+from remote_inference.capacity import BoundedWorkQueue
+
+
+class BoundedWorkQueueTest(unittest.TestCase):
+    def test_serializes_work_and_rejects_beyond_capacity(self):
+        queue = BoundedWorkQueue(concurrency=1, max_in_flight=2)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        accepted = []
+
+        def run_first():
+            with queue.reserve() as reserved:
+                accepted.append(reserved)
+                first_started.set()
+                release_first.wait(1)
+
+        def run_second():
+            with queue.reserve() as reserved:
+                accepted.append(reserved)
+
+        first = threading.Thread(target=run_first)
+        second = threading.Thread(target=run_second)
+        first.start()
+        self.assertTrue(first_started.wait(1))
+        second.start()
+        time.sleep(0.05)
+
+        with queue.reserve() as reserved:
+            self.assertFalse(reserved)
+
+        release_first.set()
+        first.join(1)
+        second.join(1)
+        self.assertEqual(accepted, [True, True])
+
+    def test_validates_limits(self):
+        with self.assertRaises(ValueError):
+            BoundedWorkQueue(concurrency=0, max_in_flight=1)
+        with self.assertRaises(ValueError):
+            BoundedWorkQueue(concurrency=2, max_in_flight=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- run synchronous background removal outside the FastAPI event loop
- bound active and queued GPU work, returning 503 when the queue is full
- send a browser User-Agent and enforce source-image download timeouts
- document capacity settings and add queue unit tests

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q remote_inference tests`